### PR TITLE
change rep name from services to service

### DIFF
--- a/scripts/github.js
+++ b/scripts/github.js
@@ -59,7 +59,7 @@ module.exports = function (robot) {
 
     github.pullRequests.getAll({owner, repo: "pac-etl", direction: "asc", state: "open", sort: "created" }, printPrs(res));
     github.pullRequests.getAll({owner, repo: "qpp-netstorage", direction: "asc", state: "open", sort: "created" }, printPrs(res));
-    github.pullRequests.getAll({owner, repo: "qpp-eligibility-services", direction: "asc", state: "open", sort: "created" }, printPrs(res));
+    github.pullRequests.getAll({owner, repo: "qpp-eligibility-service", direction: "asc", state: "open", sort: "created" }, printPrs(res));
     
     github.pullRequests.getAll({
       owner,


### PR DESCRIPTION
Hey @orenfromberg I think this is why the PRs from the qpp-eligibility-service repo don't show up :) 