### PR TITLE
Allow repo targeting for both githubs

### DIFF
--- a/scripts/github.js
+++ b/scripts/github.js
@@ -100,14 +100,27 @@ module.exports = function (robot) {
   robot.hear(/list open prs for (.*)\/(.*)/i, function (res) {
     let owner = res.match[1];
     let repo = res.match[2];
-
-    githubCmsGov.pullRequests.getAll({
-      owner,
-      repo,
-      direction: "asc",
-      state: "open",
-      sort: "created",
-    }, printPrs(res));
+    
+    if(owner === 'qpp') {
+      githubCmsGov.pullRequests.getAll({
+        owner,
+        repo,
+        direction: "asc",
+        state: "open",
+        sort: "created",
+      }, printPrs(res));
+    }
+    
+    if(owner === 'CMSgov') {
+       githubCom.pullRequests.getAll({
+        owner,
+        repo,
+        direction: "asc",
+        state: "open",
+        sort: "created",
+      }, printPrs(res));
+    }
+    
   });
 }
 


### PR DESCRIPTION
I want to move the listing of PRs from the main Dev channel to each team channel in Slack. For example, eligibility PRs in the Elig channel. But, eligibility has repos in both github.cms.gov and github.com.

This PR allows the "list open prs for" command for both Github Enterprise and Github.com. May be a little quick and dirty, but, it should work.